### PR TITLE
Require specific vesrsion of twilio sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.*",
-        "twilio/sdk":"dev-master"
+        "twilio/sdk":"3.12.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Require a specific version of the twilio (with tolerance for non-breaking changes) to avoid a potential breaking change on composer update in the future.
