### PR TITLE
adds func for sending messages with media urls

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -61,6 +61,19 @@ class Manager implements TwilioInterface
     }
 
     /**
+     * @param string $to
+     * @param string $message
+     * @param array  $mediaUrls
+     * @param string $from
+     *
+     * @return \Services_Twilio_Rest_Message
+     */
+    public function messageWithMedia($to, $message, $mediaUrls, $from = null)
+    {
+        return $this->defaultConnection()->messageWithMedia($to, $message, $mediaUrls, $from);
+    }
+
+    /**
      * @param string          $to
      * @param string|callable $message
      * @param array           $options

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -57,6 +57,22 @@ class Twilio implements TwilioInterface
     }
 
     /**
+     * @param string $to
+     * @param string $message
+     * @param array  $mediaUrls
+     * @param string $from
+     *
+     * @return \Services_Twilio_Rest_Message
+     */
+    public function messageWithMedia($to, $message, $mediaUrls, $from = null)
+    {
+        $twilio = $this->getTwilio();
+
+        return $twilio->account->messages->sendMessage($from ?: $this->from, $to, $message, $mediaUrls);
+    }
+
+
+    /**
      * @param string          $to
      * @param string|callable $message
      * @param array           $options

--- a/src/TwilioInterface.php
+++ b/src/TwilioInterface.php
@@ -13,6 +13,16 @@ interface TwilioInterface
     public function message($to, $message, $from = null);
 
     /**
+     * @param string $to
+     * @param string $message
+     * @param array	 $mediaUrls
+     * @param string $from
+     *
+     * @return \Services_Twilio_Rest_Message
+     */
+    public function messageWithMedia($to, $message, $mediaUrls, $from = null);
+
+    /**
      * @param string          $to
      * @param string|callable $message
      * @param array           $options


### PR DESCRIPTION
I needed to embed media in a message today – Twilio makes this easy, all you need to do is hand-off the urls for the files: [Twilio send message docs](https://www.twilio.com/docs/api/rest/sending-messages). The php twilio sdk implements it as well: [Twilio sdk docs](https://github.com/twilio/twilio-php/blob/master/Services/Twilio/Rest/Messages.php#L57).

Following the sdk's pattern here would introduce a breaking change for anyone using the `from` field, so I created another function for it. That's a pain and isn't very pretty... I haven't thought it through too much, but we're somewhat trapped by the field re-ordering as it stands.

I haven't added tests (as required per the guidelines) but didn't think this was _so_ bad compared to the existing ones.

Just thought I'd throw this up as-is to get a reaction to the api it introduces and see how that feels vs. breaking the old stuff.

I'm fairly new to PHP... if there's a clever way to handle the params better in one function, I'd love to hear about it.