### PR TITLE
Make passing PHP 7 tests mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - php:
-      - 7.0
       - hhvm
 
 before_install:


### PR DESCRIPTION
PHP 7 is just around the corner. Let's make sure your package is ready from day 1.