### PR TITLE
Fixed memory leak.

### DIFF
--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -27,6 +27,11 @@ class Twilio implements TwilioInterface
      * @var bool
      */
     protected $sslVerify;
+    
+    /**
+     * @var \Services_Twilio
+     */
+     protected $twilio;
 
     /**
      * @param string $token
@@ -99,6 +104,10 @@ class Twilio implements TwilioInterface
      */
     public function getTwilio()
     {
+        if ($this->twilio) {
+            return $this->twilio;
+        }
+        
         if (!$this->sslVerify) {
             $http = new Services_Twilio_TinyHttp(
                 'https://api.twilio.com',
@@ -110,8 +119,10 @@ class Twilio implements TwilioInterface
                 ]
             );
         }
+        
+        $this->twilio = new Services_Twilio($this->sid, $this->token, null, isset($http) ? $http : null);
 
-        return new Services_Twilio($this->sid, $this->token, null, isset($http) ? $http : null);
+        return $this->twilio;
     }
 
     /**


### PR DESCRIPTION
Creating a new Services_Twilio object on every call to one of the helper functions results in a memory leak in long-running scripts.