### PR TITLE
Fix version constraint for twilio/sdk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.5.0",
-        "twilio/sdk":">=3.12.0"
+        "twilio/sdk":"^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.9",


### PR DESCRIPTION
Fixes #135 

I see no reason not to fix the version constraint here, instead of asking end-users to override the dependencies locally.

This will prevent peoples' existing deployments from breaking if and until the authors add support for `twilio/sdk >= 5.0`.