### PR TITLE
Added Laravel 5.1 fix for cli commands

### DIFF
--- a/src/Commands/TwilioCallCommand.php
+++ b/src/Commands/TwilioCallCommand.php
@@ -59,6 +59,14 @@ class TwilioCallCommand extends Command
     }
 
     /**
+     * Proxy method for Laravel 5.1+
+     */
+    public function handle()
+    {
+        return $this->fire();
+    }
+
+    /**
      * Get the console command arguments.
      *
      * @return array

--- a/src/Commands/TwilioSmsCommand.php
+++ b/src/Commands/TwilioSmsCommand.php
@@ -59,6 +59,14 @@ class TwilioSmsCommand extends Command
     }
 
     /**
+     * Proxy method for Laravel 5.1+
+     */
+    public function handle()
+    {
+        return $this->fire();
+    }
+
+    /**
      * Get the console command arguments.
      *
      * @return array


### PR DESCRIPTION
### Fixed

- Laravel 5.1 (and up) calls method `handle` on console commands instead of `fire`

--- 
fixes #140 