### PR TITLE
Support Laravel 5.5+ auto package discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ Begin by installing this package through Composer. Run this command from the Ter
 ```bash
 composer require aloha/twilio
 ```
+If you're using Laravel 5.5+, this is all there is to do.
 
-## Laravel integration
+Should you still be on older versions of Laravel, the final steps for you are to add the service provider of the package and alias the package. To do this open your `config/app.php` file.
 
-To wire this up in your Laravel project, whether it's built in Laravel 4 or 5, you need to add the service provider.
+## Integration for older versions of Laravel (5.5 -)
+
+To wire this up in your Laravel project, you need to add the service provider.
 Open `app.php`, and add a new item to the providers array.
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,15 @@
         "test": "phpunit",
         "cs": "php-cs-fixer fix src/ --level=psr2"
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Aloha\\Twilio\\Support\\Laravel\\ServiceProvider"
+            ],
+            "aliases": {
+                "Twilio": "Aloha\\Twilio\\Support\\Laravel\\Facade"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Laravel 5.5+ ships with auto package discovery which automates the addition of ServiceProviders and Aliases to the config/app.php. This pull request adds this feature to this package to enable users running on Laravel 5.5+ enjoy it. Users on older versions can however still use the package but must still add the Providers and Aliases to the config/app.php file.