### PR TITLE
Allow faking of API requests in dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ if (getenv('APP_ENV') === 'production') {
 $notifier = new Notifier($twilio);
 ```
 
+#### Only log API requests in development environments
+
+Enabling the `'fake'` configuration in `config/twilio.php` will write messages to
+the log file and suppress external HTTP requests to Twilio's service.
+
+When testing a development or UAT environment with actual phone numbers, this setting
+is useful in preventing accidental SMS deliveries.
+
 ## Credits
 
 - [Hannes Van De Vreken](https://twitter.com/hannesvdvreken)

--- a/src/Support/Laravel/ServiceProviderTrait.php
+++ b/src/Support/Laravel/ServiceProviderTrait.php
@@ -4,14 +4,23 @@ namespace Aloha\Twilio\Support\Laravel;
 use Aloha\Twilio\Commands\TwilioCallCommand;
 use Aloha\Twilio\Commands\TwilioSmsCommand;
 use Aloha\Twilio\Manager;
+use Aloha\Twilio\TwilioFake;
 use Aloha\Twilio\TwilioInterface;
 
 trait ServiceProviderTrait
 {
-    /**
-     *
-     */
     public function register()
+    {
+        if ($this->shouldFakeRequests()) {
+            $this->registerFake();
+        } else {
+            $this->registerManager();
+        }
+
+        $this->registerCommands();
+    }
+
+    protected function registerManager()
     {
         // Register manager for usage with the Facade.
         $this->app->singleton('twilio', function () {
@@ -23,15 +32,32 @@ trait ServiceProviderTrait
         // Define an alias.
         $this->app->alias('twilio', Manager::class);
 
+        // Register TwilioInterface concretion.
+        $this->app->singleton(TwilioInterface::class, function () {
+            return $this->app->make('twilio')->defaultConnection();
+        });
+    }
+
+    protected function registerFake()
+    {
+        // Facade will access fake implementation.
+        $this->app->singleton('twilio', TwilioFake::class);
+
+        // App container will resolve to the same fake singleton.
+        $this->app->singleton(TwilioInterface::class, 'twilio');
+    }
+
+    protected function registerCommands()
+    {
         // Register Twilio Test SMS Command.
         $this->app->singleton('twilio.sms', TwilioSmsCommand::class);
 
         // Register Twilio Test Call Command.
         $this->app->singleton('twilio.call', TwilioCallCommand::class);
+    }
 
-        // Register TwilioInterface concretion.
-        $this->app->singleton(TwilioInterface::class, function () {
-            return $this->app->make('twilio')->defaultConnection();
-        });
+    protected function shouldFakeRequests()
+    {
+        return !empty($this->config()['fake']);
     }
 }

--- a/src/TwilioFake.php
+++ b/src/TwilioFake.php
@@ -1,0 +1,74 @@
+<?php
+namespace Aloha\Twilio;
+
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+class TwilioFake implements TwilioInterface
+{
+    /**
+     * @var LoggingDecorator
+     */
+    protected $logger;
+
+    /**
+     * @var LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = new LoggingDecorator($logger, new Dummy);
+    }
+
+    /**
+     * @return TwilioInterface
+     */
+    public function from()
+    {
+        return $this;
+    }
+
+    /**
+     * @return TwilioInterface
+     */
+    public function getConnection()
+    {
+        return $this;
+    }
+
+    /**
+     * @param string $to
+     * @param string|callable $message
+     *
+     * @return void
+     */
+    public function message($to, $message)
+    {
+        return call_user_func_array([$this->logger, 'message'], func_get_args());
+    }
+
+    /**
+     * @param string $to
+     * @param string|callable $message
+     *
+     * @return void
+     */
+    public function call($to, $message)
+    {
+        return call_user_func_array([$this->logger, 'call'], func_get_args());
+    }
+
+    /**
+     * @param string $method
+     * @param array $arguments
+     *
+     * @throws RuntimeException
+     *
+     * @return void
+     */
+    public function __call($method, $arguments)
+    {
+        throw new RuntimeException(
+            "Can't call Twilio@{$method}() when faking API requests."
+        );
+    }
+}

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -56,5 +56,7 @@ return [
                 'ssl_verify' => true,
             ],
         ],
+
+        'fake' => getenv('TWILIO_FAKE') ?: false,
     ],
 ];


### PR DESCRIPTION
Solution for https://github.com/aloha/laravel-twilio/issues/122

* `Config::set('twilio.twilio.fake', true)` (environment variable `TWILIO_FAKE`) will stop external API requests to Twilio's servers.
* This allows a local dev machine to just log messages and calls to resources/logs/laravel.log

I decided not to enable this fake mode when credentials are empty as it will affect first-time (or even current) installs. You'd rather the the first API request throw an exception rather than silently writing a log file entry.

## Testing

I tried writing some tests (https://github.com/derekmd/laravel-twilio/commits/add-fake-class) to cover the service provider making the correct container bindings given a config but I believe the whole `laravel/framework` package has to be pulled in as a composer `require-dev` dependencies for `TestCase` app container setup.

## Follow-up idea

* For testing, add `Aloha\Twilio\Support\Laravel\Facade@fake()` to swap `TwilioFake` into the container.
* Add  `TwilioFake@assertMessageSent()` and `TwilioFake@assertCallSent()` for L5.4+-style automated testing that doesn't require mock objects.