### PR TITLE
Update docblock for twilio/sdk 5.*

### DIFF
--- a/src/Dummy.php
+++ b/src/Dummy.php
@@ -7,7 +7,7 @@ class Dummy implements TwilioInterface
      * @param string $to
      * @param string $message
      *
-     * @return \Services_Twilio_Rest_Call|void
+     * @return \Twilio\Rest\Api\V2010\Account\MessageInstance|void
      */
     public function message($to, $message)
     {
@@ -17,7 +17,7 @@ class Dummy implements TwilioInterface
      * @param string $to
      * @param string|callable $message
      *
-     * @return \Services_Twilio_Rest_Call|void
+     * @return \Twilio\Rest\Api\V2010\Account\CallInstance|void
      */
     public function call($to, $message)
     {

--- a/src/LoggingDecorator.php
+++ b/src/LoggingDecorator.php
@@ -29,7 +29,7 @@ class LoggingDecorator implements TwilioInterface
      * @param string $to
      * @param string $message
      *
-     * @return \Services_Twilio_Rest_Message
+     * @return \Twilio\Rest\Api\V2010\Account\MessageInstance
      */
     public function message($to, $message)
     {
@@ -42,7 +42,7 @@ class LoggingDecorator implements TwilioInterface
      * @param string $to
      * @param string|callable $message
      *
-     * @return \Services_Twilio_Rest_Call
+     * @return \Twilio\Rest\Api\V2010\Account\CallInstance
      */
     public function call($to, $message)
     {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -45,7 +45,7 @@ class Manager implements TwilioInterface
      * @param string $to
      * @param string $message
      *
-     * @return \Services_Twilio_Rest_Message
+     * @return \Twilio\Rest\Api\V2010\Account\MessageInstance
      */
     public function message($to, $message)
     {
@@ -56,7 +56,7 @@ class Manager implements TwilioInterface
      * @param string $to
      * @param string|callable $message
      *
-     * @return \Services_Twilio_Rest_Call
+     * @return \Twilio\Rest\Api\V2010\Account\CallInstance
      */
     public function call($to, $message)
     {

--- a/src/Twilio.php
+++ b/src/Twilio.php
@@ -73,6 +73,7 @@ class Twilio implements TwilioInterface
     /**
      * @param string $to
      * @param string|callable $message
+     * @param array $params
      *
      * @link https://www.twilio.com/docs/api/voice/making-calls Documentation
      *

--- a/src/TwilioInterface.php
+++ b/src/TwilioInterface.php
@@ -7,7 +7,7 @@ interface TwilioInterface
      * @param string $to
      * @param string $message
      *
-     * @return \Services_Twilio_Rest_Message
+     * @return \Twilio\Rest\Api\V2010\Account\MessageInstance
      */
     public function message($to, $message);
 
@@ -15,7 +15,7 @@ interface TwilioInterface
      * @param string $to
      * @param string|callable $message
      *
-     * @return \Services_Twilio_Rest_Call
+     * @return \Twilio\Rest\Api\V2010\Account\CallInstance
      */
     public function call($to, $message);
 }

--- a/tests/TwilioCallCommandTest.php
+++ b/tests/TwilioCallCommandTest.php
@@ -2,7 +2,6 @@
 namespace Aloha\Twilio\Tests;
 
 use Aloha\Twilio\Commands\TwilioCallCommand;
-use Aloha\Twilio\Twilio;
 use PHPUnit_Framework_TestCase;
 
 class TwilioCallCommandTest extends PHPUnit_Framework_TestCase


### PR DESCRIPTION
Update interface `@return` docblock to match concrete class `Aloha\Twilio\Twilio` typehints for the new SDK.