### PR TITLE
Add facade Twilio::fake() for testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,12 @@
         "friendsofphp/php-cs-fixer": "^1.9",
         "illuminate/console": "~4||~5",
         "illuminate/support": "~4||~5",
+        "orchestra/testbench": "~3.0",
         "phpunit/phpunit": "~4.5"
+    },
+    "suggest": {
+        "illuminate/support": "Allow tests using a facade fake (~4||~5).",
+        "phpunit/phpunit": "Allow tests using a facade fake (~4.5)."
     },
     "autoload": {
         "psr-4": {

--- a/src/Support/Laravel/Facade.php
+++ b/src/Support/Laravel/Facade.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aloha\Twilio\Support\Laravel;
 
+use Aloha\Twilio\Support\Testing\TwilioFake;
 use Illuminate\Support\Facades\Facade as BaseFacade;
 
 class Facade extends BaseFacade
@@ -13,5 +14,13 @@ class Facade extends BaseFacade
     protected static function getFacadeAccessor()
     {
         return 'twilio';
+    }
+
+    /**
+     * Replace the bound instance with a fake.
+     */
+    public static function fake()
+    {
+        static::swap(static::$app->make(TwilioFake::class));
     }
 }

--- a/src/Support/Testing/LogDriver.php
+++ b/src/Support/Testing/LogDriver.php
@@ -1,0 +1,39 @@
+<?php
+namespace Aloha\Twilio\Support\Testing;
+
+use Aloha\Twilio\TwilioInterface;
+use Psr\Log\LoggerInterface;
+
+class LogDriver implements TwilioInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param string $to
+     * @param string $message
+     */
+    public function message($to, $message)
+    {
+        $this->logger->info("Sending a message [\"{$message}\"] to {$to}");
+    }
+
+    /**
+     * @param string $to
+     * @param string|callable $message
+     */
+    public function call($to, $message)
+    {
+        $this->logger->info("Calling {$to}");
+    }
+}

--- a/src/Support/Testing/TwilioFake.php
+++ b/src/Support/Testing/TwilioFake.php
@@ -1,0 +1,112 @@
+<?php
+namespace Aloha\Twilio\Support\Testing;
+
+use Aloha\Twilio\TwilioInterface;
+use PHPUnit\Framework\Assert as PHPUnit;
+use Psr\Log\LoggerInterface;
+
+class TwilioFake implements TwilioInterface
+{
+    protected $calls = [];
+    protected $connection;
+    protected $logger;
+    protected $messages = [];
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = new LogDriver($logger);
+    }
+
+    /**
+     * @param string $connection
+     *
+     * @return $this
+     */
+    public function from($connection)
+    {
+        $this->connection = $connection;
+
+        return $this;
+    }
+
+    /**
+     * @param string $to
+     * @param string $message
+     */
+    public function call($to, $message)
+    {
+        $this->calls[] = (object) [
+            'to' => $to,
+            'message' => $message,
+            'connection' => $this->connection,
+        ];
+
+        call_user_func_array([$this->logger, 'call'], func_get_args());
+    }
+
+    /**
+     * @param string $to
+     * @param string $message
+     */
+    public function message($to, $message)
+    {
+        $this->messages[] = (object) [
+            'to' => $to,
+            'message' => $message,
+            'connection' => $this->connection,
+        ];
+
+        call_user_func_array([$this->logger, 'message'], func_get_args());
+    }
+
+    /**
+     * @param string $to
+     * @param string $message
+     * @param string|null $connection
+     *
+     * @return $this
+     */
+    public function assertCallSent($to, $message, $connection = null)
+    {
+        PHPUnit::assertTrue(
+            $this->sent($this->calls, $to, $message, $connection)->count() > 0,
+            "The expected [{$message}] call was not sent."
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param string $to
+     * @param string $message
+     * @param string|null $connection
+     *
+     * @return $this
+     */
+    public function assertMessageSent($to, $message, $connection = null)
+    {
+        PHPUnit::assertTrue(
+            $this->sent($this->messages, $to, $message, $connection)->count() > 0,
+            "The expected [{$message}] message was not sent."
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param array $twilioRequests
+     * @param string $to
+     * @param string $message
+     * @param string|null $connection
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function sent($twilioRequests, $to, $message, $connection)
+    {
+        return collect($twilioRequests)->filter(function ($twilioRequest) use ($to, $message, $connection) {
+            return $twilioRequest->to === $to && $twilioRequest->message === $message && (
+                is_null($connection) || $twilioRequest->connection === $connection
+            );
+        });
+    }
+}

--- a/tests/TwilioCallCommandTest.php
+++ b/tests/TwilioCallCommandTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Aloha\Twilio\Tests;
+namespace Tests;
 
 use Aloha\Twilio\Commands\TwilioCallCommand;
 use PHPUnit_Framework_TestCase;

--- a/tests/TwilioFakeTest.php
+++ b/tests/TwilioFakeTest.php
@@ -1,0 +1,64 @@
+<?php
+namespace Tests;
+
+use Aloha\Twilio\Support\Laravel\Facade as Twilio;
+use Orchestra\Testbench\TestCase;
+
+class TwilioFakeTest extends TestCase
+{
+    public function testItCanFakePhoneCalls()
+    {
+        Twilio::fake();
+
+        Twilio::from('default')->call('+15551234567', 'phone call fake');
+
+        Twilio::assertCallSent('+15551234567', 'phone call fake');
+        Twilio::assertCallSent('+15551234567', 'phone call fake', 'default');
+    }
+
+    public function testItCanFakeMessages()
+    {
+        Twilio::fake();
+
+        Twilio::message('+32474123456', 'message fake');
+
+        Twilio::assertMessageSent('+32474123456', 'message fake');
+    }
+
+    public function testItWillThrowAnExceptionWhenPhoneCallWasNotMade()
+    {
+        $this->expectAssertionFailedException('The expected [phone call not found] call was not sent.');
+
+        Twilio::fake();
+
+        Twilio::call('+15551234567', 'phone call fake');
+
+        Twilio::assertCallSent('+15551234567', 'phone call not found');
+    }
+
+    public function testItWillThrowAnExceptionWhenMessageWasNotMadeOnTheSameConnection()
+    {
+        $this->expectAssertionFailedException('The expected [another connection] message was not sent.');
+
+        Twilio::fake();
+
+        Twilio::from('europe')->message('+32474123456', 'another connection');
+
+        Twilio::assertMessageSent('+32474123456', 'another connection', 'north-america');
+    }
+
+    protected function expectAssertionFailedException($message)
+    {
+        if ($this->isNamespacedPHPUnit()) {
+            $this->expectException(\PHPUnit\Framework\AssertionFailedError::class);
+            $this->expectExceptionMessage($message);
+        } else {
+            $this->setExpectedException(\PHPUnit_Framework_AssertionFailedError::class, $message);
+        }
+    }
+
+    protected function isNamespacedPHPUnit()
+    {
+        return method_exists($this, 'expectException') && !method_exists($this, 'setExpectedException');
+    }
+}

--- a/tests/TwilioSmsCommandTest.php
+++ b/tests/TwilioSmsCommandTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Aloha\Twilio\Tests;
+namespace Tests;
 
 use Aloha\Twilio\Commands\TwilioSmsCommand;
 use PHPUnit_Framework_TestCase;


### PR DESCRIPTION
In the style of Laravel 5.4+ [test faker classes](https://github.com/laravel/framework/tree/master/src/Illuminate/Support/Testing/Fakes).

e.g.,

```php
use Twilio;

public function it_can_notify_via_text_message_from_european_phone_number()
{
    Twilio::fake();

    // request API endpoint that calls Twilio::from('europe')->message(+32474123456', 'Hello')

    Twilio::assertMessageSent('+32474123456', 'Hello', 'europe');

    // Or if you don't want to check which connection:
    Twilio::assertMessageSent('+32474123456', 'Hello');
}
```

There's also a `Twilio::assertCallSent('+1....', 'expected message')` for phone calls. All activity is stored to the Laravel log file for debugging.

With these faker classes you can get into `assertNotSent()`, `assertSentTimes()`, etc. so I thought I would just add the simplest use cases unless devs demand more assertion methods.

> I had to perform uncomfortable trial-and-error to get the new tests working across PHPUnit 4.8.36, 5.7.23, and 6.4.3. TravisCI seemingly has multiple versions available in the class loader. These aren't really forward-compatible (and typehint-happy PHPUnit 7 will be even worse) so it might be a good idea to lock in a newer `require-dev` version whilst still keeping Laravel >4.* support in the package itself.