### PR TITLE
Upgrade twilio/sdk to 6.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
 
 before_install:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "homepage":"https://github.com/aloha/laravel-twilio",
     "license": "MIT",
     "require": {
-        "php": ">=5.5.0",
-        "twilio/sdk":"5.*"
+        "php": ">=7.2.0",
+        "twilio/sdk": "6.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.9",


### PR DESCRIPTION
I started this because of this issue https://github.com/aloha/laravel-twilio/issues/175

This pull request updates the `twilio/sdk` package to `6.*`. This also requires that we update our PHP requirement to `>=7.2.0`. Because of this, I suggest that we make this a major version change.

I don't think we need to change anything else. From the [Twilio docs](https://www.twilio.com/docs/libraries/php): "The Twilio SDK requires PHP version 7.2 or higher. The 6.x version of the Twilio PHP SDK is API-compatible with the previous 5.x version."

